### PR TITLE
Adding support for volumetric points to the nanoflann.

### DIFF
--- a/examples/KDTreeVectorOfVectorsAdaptor.h
+++ b/examples/KDTreeVectorOfVectorsAdaptor.h
@@ -118,6 +118,20 @@ struct KDTreeVectorOfVectorsAdaptor
         return m_data[idx][dim];
     }
 
+    // Get limits for list of points
+    inline void kdtree_get_limits(
+        const IndexType* ix, size_t count, const size_t dim, num_t& limit_min,
+        num_t& limit_max) const
+    {
+        limit_min = limit_max = kdtree_get_pt(ix[0], dim);
+        for (size_t k = 1; k < count; ++k)
+        {
+            const num_t value = kdtree_get_pt(ix[k], dim);
+            if (value < limit_min) limit_min = value;
+            if (value > limit_max) limit_max = value;
+        }
+    }
+
     // Optional bounding-box computation: return false to default to a standard
     // bbox computation loop.
     // Return true if the BBOX was already computed by the class and returned

--- a/examples/KDTreeVectorOfVectorsAdaptor.h
+++ b/examples/KDTreeVectorOfVectorsAdaptor.h
@@ -61,6 +61,23 @@ struct KDTreeVectorOfVectorsAdaptor
     using index_t =
         nanoflann::KDTreeSingleIndexAdaptor<metric_t, self_t, DIM, IndexType>;
 
+    /* Adaptor for a Point */
+    struct PointAdaptor
+    {
+        const typename VectorOfVectorsType::value_type& row;
+
+        inline num_t get_component(size_t dim) const
+        {
+            return row[dim];
+        }
+
+        inline num_t get_signed_distance(size_t dim, num_t val) const
+        {
+            return row[dim] - val;
+        }
+    };
+    using PointType = PointAdaptor;
+
     /** The kd-tree index for the user to call its methods as usual with any
      * other FLANN index */
     index_t* index = nullptr;
@@ -113,9 +130,9 @@ struct KDTreeVectorOfVectorsAdaptor
     inline size_t kdtree_get_point_count() const { return m_data.size(); }
 
     // Returns the dim'th component of the idx'th point in the class:
-    inline num_t kdtree_get_pt(const size_t idx, const size_t dim) const
+    inline PointType kdtree_get_pt(const size_t idx) const
     {
-        return m_data[idx][dim];
+        return PointType{m_data[idx]};
     }
 
     // Get limits for list of points
@@ -123,10 +140,10 @@ struct KDTreeVectorOfVectorsAdaptor
         const IndexType* ix, size_t count, const size_t dim, num_t& limit_min,
         num_t& limit_max) const
     {
-        limit_min = limit_max = kdtree_get_pt(ix[0], dim);
+        limit_min = limit_max = kdtree_get_pt(ix[0]).get_component(dim);
         for (size_t k = 1; k < count; ++k)
         {
-            const num_t value = kdtree_get_pt(ix[k], dim);
+            const num_t value = kdtree_get_pt(ix[k]).get_component(dim);
             if (value < limit_min) limit_min = value;
             if (value > limit_max) limit_max = value;
         }

--- a/examples/SO2_adaptor_example.cpp
+++ b/examples/SO2_adaptor_example.cpp
@@ -41,7 +41,7 @@ void kdtree_demo(const size_t N)
     // Generate points:
     generateRandomPointCloud_Orient(cloud, N);
 
-    num_t query_pt[1] = {0.5};
+    const PointCloud_Orient<num_t>::Point query_pt{0.5};
 
     // construct a kd-tree index:
     using my_kd_tree_t = nanoflann::KDTreeSingleIndexAdaptor<
@@ -61,7 +61,7 @@ void kdtree_demo(const size_t N)
         num_t                          out_dist_sqr;
         nanoflann::KNNResultSet<num_t> resultSet(num_results);
         resultSet.init(&ret_index, &out_dist_sqr);
-        index.findNeighbors(resultSet, &query_pt[0]);
+        index.findNeighbors(resultSet, query_pt);
 
         std::cout << "knnSearch(nn=" << num_results << "): \n";
         std::cout << "ret_index=" << ret_index

--- a/examples/SO3_adaptor_example.cpp
+++ b/examples/SO3_adaptor_example.cpp
@@ -41,7 +41,7 @@ void kdtree_demo(const size_t N)
     // Generate points:
     generateRandomPointCloud_Quat(cloud, N);
 
-    num_t query_pt[4] = {0.5, 0.5, 0.5, 0.5};
+    const PointCloud_Quat<num_t>::Point query_pt{0.5, 0.5, 0.5, 0.5};
 
     // construct a kd-tree index:
     using my_kd_tree_t = nanoflann::KDTreeSingleIndexAdaptor<
@@ -61,7 +61,7 @@ void kdtree_demo(const size_t N)
         num_t                          out_dist_sqr;
         nanoflann::KNNResultSet<num_t> resultSet(num_results);
         resultSet.init(&ret_index, &out_dist_sqr);
-        index.findNeighbors(resultSet, &query_pt[0]);
+        index.findNeighbors(resultSet, query_pt);
 
         std::cout << "knnSearch(nn=" << num_results << "): \n";
         std::cout << "ret_index=" << ret_index

--- a/examples/dynamic_pointcloud_example.cpp
+++ b/examples/dynamic_pointcloud_example.cpp
@@ -51,7 +51,7 @@ void kdtree_demo(const size_t N)
     // Generate points:
     generateRandomPointCloud(cloud, N);
 
-    num_t query_pt[3] = {0.5, 0.5, 0.5};
+    const PointCloud<num_t>::Point query_pt{0.5, 0.5, 0.5};
 
     // add points in chunks at a time
     size_t chunk_size = 100;

--- a/examples/pointcloud_adaptor_example.cpp
+++ b/examples/pointcloud_adaptor_example.cpp
@@ -70,6 +70,20 @@ struct PointCloudAdaptor
             return derived().pts[idx].z;
     }
 
+    // Get limits for list of points
+    inline void kdtree_get_limits(
+        const uint32_t* ix, size_t count, const size_t dim, coord_t& limit_min,
+        coord_t& limit_max) const
+    {
+        limit_min = limit_max = kdtree_get_pt(ix[0], dim);
+        for (size_t k = 1; k < count; ++k)
+        {
+            const coord_t value = kdtree_get_pt(ix[k], dim);
+            if (value < limit_min) limit_min = value;
+            if (value > limit_max) limit_max = value;
+        }
+    }
+
     // Optional bounding-box computation: return false to default to a standard
     // bbox computation loop.
     //   Return true if the BBOX was already computed by the class and returned

--- a/examples/pointcloud_adaptor_example.cpp
+++ b/examples/pointcloud_adaptor_example.cpp
@@ -42,6 +42,27 @@ struct PointCloudAdaptor
 {
     using coord_t = typename Derived::coord_t;
 
+    struct PointAdaptor
+    {
+        const typename Derived::PointType& point;
+
+        inline coord_t get_component(size_t dim) const
+        {
+            return point.get_component(dim);
+        }
+
+        inline coord_t get_signed_distance(size_t dim, coord_t val) const
+        {
+            return point.get_signed_distance(dim, val);
+        }
+
+        inline coord_t get_distance_to(const PointAdaptor& pt) const
+        {
+            return point.get_distance_to(pt.point);
+        }
+    };
+    using PointType = PointAdaptor;
+
     const Derived& obj;  //!< A const ref to the data set origin
 
     /// The constructor that sets the data set source
@@ -60,14 +81,9 @@ struct PointCloudAdaptor
     // Since this is inlined and the "dim" argument is typically an immediate
     // value, the
     //  "if/else's" are actually solved at compile time.
-    inline coord_t kdtree_get_pt(const size_t idx, const size_t dim) const
+    inline PointAdaptor kdtree_get_pt(const size_t idx) const
     {
-        if (dim == 0)
-            return derived().pts[idx].x;
-        else if (dim == 1)
-            return derived().pts[idx].y;
-        else
-            return derived().pts[idx].z;
+        return PointAdaptor{derived().pts[idx]};
     }
 
     // Get limits for list of points
@@ -75,24 +91,13 @@ struct PointCloudAdaptor
         const uint32_t* ix, size_t count, const size_t dim, coord_t& limit_min,
         coord_t& limit_max) const
     {
-        limit_min = limit_max = kdtree_get_pt(ix[0], dim);
+        limit_min = limit_max = kdtree_get_pt(ix[0]).get_component(dim);
         for (size_t k = 1; k < count; ++k)
         {
-            const coord_t value = kdtree_get_pt(ix[k], dim);
+            const coord_t value = kdtree_get_pt(ix[k]).get_component(dim);
             if (value < limit_min) limit_min = value;
             if (value > limit_max) limit_max = value;
         }
-    }
-
-    // Optional bounding-box computation: return false to default to a standard
-    // bbox computation loop.
-    //   Return true if the BBOX was already computed by the class and returned
-    //   in "bb" so it can be avoided to redo it again. Look at bb.size() to
-    //   find out the expected dimensionality (e.g. 2 or 3 for point clouds)
-    template <class BBOX>
-    bool kdtree_get_bbox(BBOX& /*bb*/) const
-    {
-        return false;
     }
 
 };  // end of PointCloudAdaptor
@@ -121,10 +126,10 @@ void kdtree_demo(const size_t N)
         size_t                         ret_index;
         num_t                          out_dist_sqr;
         nanoflann::KNNResultSet<num_t> resultSet(num_results);
-        num_t                          query_pt[3] = {0.5, 0.5, 0.5};
+        const PointCloud<num_t>::Point query_pt{0.5, 0.5, 0.5};
 
         resultSet.init(&ret_index, &out_dist_sqr);
-        index.findNeighbors(resultSet, &query_pt[0]);
+        index.findNeighbors(resultSet, {query_pt});
 
         std::cout << "knnSearch(nn=" << num_results << "): \n";
         std::cout << "ret_index=" << ret_index

--- a/examples/pointcloud_custom_resultset.cpp
+++ b/examples/pointcloud_custom_resultset.cpp
@@ -98,7 +98,7 @@ void kdtree_demo(const size_t N)
     // Generate points:
     generateRandomPointCloud(cloud, N);
 
-    num_t query_pt[3] = {0.5, 0.5, 0.5};
+    const PointCloud<num_t>::Point query_pt{0.5, 0.5, 0.5};
 
     // construct a kd-tree index:
     using my_kd_tree_t = nanoflann::KDTreeSingleIndexAdaptor<

--- a/examples/pointcloud_example.cpp
+++ b/examples/pointcloud_example.cpp
@@ -46,7 +46,7 @@ void kdtree_demo(const size_t N)
     // Generate points:
     generateRandomPointCloud(cloud, N);
 
-    num_t query_pt[3] = {0.5, 0.5, 0.5};
+    const PointCloud<num_t>::Point query_pt{0.5, 0.5, 0.5};
 
     // construct a kd-tree index:
     using my_kd_tree_t = nanoflann::KDTreeSingleIndexAdaptor<
@@ -66,7 +66,7 @@ void kdtree_demo(const size_t N)
         num_t                          out_dist_sqr;
         nanoflann::KNNResultSet<num_t> resultSet(num_results);
         resultSet.init(&ret_index, &out_dist_sqr);
-        index.findNeighbors(resultSet, &query_pt[0]);
+        index.findNeighbors(resultSet, query_pt);
 
         std::cout << "knnSearch(nn=" << num_results << "): \n";
         std::cout << "ret_index=" << ret_index

--- a/examples/pointcloud_kdd_radius.cpp
+++ b/examples/pointcloud_kdd_radius.cpp
@@ -58,7 +58,7 @@ void kdtree_demo(const size_t N)
 	index.buildIndex();
 #endif
 
-    const num_t query_pt[3] = {0.5, 0.5, 0.5};
+    const PointCloud<num_t>::Point query_pt{0.5, 0.5, 0.5};
 
     // ----------------------------------------------------------------
     // knnSearch():  Perform a search for the N closest points
@@ -69,7 +69,7 @@ void kdtree_demo(const size_t N)
         std::vector<num_t>    out_dist_sqr(num_results);
 
         num_results = index.knnSearch(
-            &query_pt[0], num_results, &ret_index[0], &out_dist_sqr[0]);
+            query_pt, num_results, &ret_index[0], &out_dist_sqr[0]);
 
         // In case of less points in the tree than requested:
         ret_index.resize(num_results);
@@ -93,7 +93,7 @@ void kdtree_demo(const size_t N)
         // params.sorted = false;
 
         const size_t nMatches =
-            index.radiusSearch(&query_pt[0], search_radius, ret_matches);
+            index.radiusSearch(query_pt, search_radius, ret_matches);
 
         cout << "radiusSearch(): radius=" << search_radius << " -> " << nMatches
              << " matches\n";

--- a/examples/saveload_example.cpp
+++ b/examples/saveload_example.cpp
@@ -41,7 +41,7 @@ void kdtree_save_load_demo(const size_t N)
     // Generate points:
     generateRandomPointCloud(cloud, N);
 
-    double query_pt[3] = {0.5, 0.5, 0.5};
+    const PointCloud<double>::Point query_pt{0.5, 0.5, 0.5};
 
     // construct a kd-tree index:
     using my_kd_tree_t = nanoflann::KDTreeSingleIndexAdaptor<
@@ -90,7 +90,7 @@ void kdtree_save_load_demo(const size_t N)
         double                          out_dist_sqr;
         nanoflann::KNNResultSet<double> resultSet(num_results);
         resultSet.init(&ret_index, &out_dist_sqr);
-        index.findNeighbors(resultSet, &query_pt[0]);
+        index.findNeighbors(resultSet, query_pt);
 
         std::cout << "knnSearch(nn=" << num_results << "): \n";
         std::cout << "ret_index=" << ret_index

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -150,14 +150,15 @@ void generateGridPointCloud(
     PointCloud<T>& point, const size_t X, const size_t Y, const size_t Z,
     const T cell_size = 1)
 {
-    point.pts.resize(X * Y * Z);
+    const auto offset = point.pts.size();
+    point.pts.resize(offset + X * Y * Z);
     for (size_t z = 0; z < Z; ++z)
     {
         for (size_t y = 0; y < Y; ++y)
         {
             for (size_t x = 0; x < X; ++x)
             {
-                const size_t ix = x + y * X + z * X * Y;
+                const size_t ix = offset + x + y * X + z * X * Y;
                 point.pts[ix].x = x * cell_size;
                 point.pts[ix].y = y * cell_size;
                 point.pts[ix].z = z * cell_size;

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -59,6 +59,19 @@ struct PointCloud
             return pts[idx].z;
     }
 
+    // Get limits for list of points
+    inline void kdtree_get_limits(
+        const uint32_t* ix, size_t count, const size_t dim, T& limit_min, T& limit_max) const
+    {
+        limit_min = limit_max = kdtree_get_pt(ix[0], dim);
+        for (size_t k = 1; k < count; ++k)
+        {
+            const T value = kdtree_get_pt(ix[k], dim);
+            if (value < limit_min) limit_min = value;
+            if (value > limit_max) limit_max = value;
+        }
+    }
+
     // Optional bounding-box computation: return false to default to a standard
     // bbox computation loop.
     //   Return true if the BBOX was already computed by the class and returned
@@ -123,6 +136,20 @@ struct PointCloud_Quat
             return pts[idx].z;
     }
 
+    // Get limits for list of points
+    inline void kdtree_get_limits(
+        const uint32_t* ix, size_t count, const size_t dim, T& limit_min,
+        T& limit_max) const
+    {
+        limit_min = limit_max = kdtree_get_pt(ix[0], dim);
+        for (size_t k = 1; k < count; ++k)
+        {
+            const T value = kdtree_get_pt(ix[k], dim);
+            if (value < limit_min) limit_min = value;
+            if (value > limit_max) limit_max = value;
+        }
+    }
+
     // Optional bounding-box computation: return false to default to a standard
     // bbox computation loop.
     //   Return true if the BBOX was already computed by the class and returned
@@ -183,6 +210,20 @@ struct PointCloud_Orient
     inline T kdtree_get_pt(const size_t idx, const size_t dim = 0) const
     {
         return pts[idx].theta;
+    }
+
+    // Get limits for list of points
+    inline void kdtree_get_limits(
+        const uint32_t* ix, size_t count, const size_t dim, T& limit_min,
+        T& limit_max) const
+    {
+        limit_min = limit_max = kdtree_get_pt(ix[0], dim);
+        for (size_t k = 1; k < count; ++k)
+        {
+            const T value = kdtree_get_pt(ix[k], dim);
+            if (value < limit_min) limit_min = value;
+            if (value > limit_max) limit_max = value;
+        }
     }
 
     // Optional bounding-box computation: return false to default to a standard

--- a/examples/vector_of_vectors_example.cpp
+++ b/examples/vector_of_vectors_example.cpp
@@ -84,7 +84,7 @@ void kdtree_demo(const size_t nSamples, const size_t dim)
     nanoflann::KNNResultSet<double> resultSet(num_results);
 
     resultSet.init(&ret_indexes[0], &out_dists_sqr[0]);
-    mat_index.index->findNeighbors(resultSet, &query_pt[0]);
+    mat_index.index->findNeighbors(resultSet, {query_pt});
 
     std::cout << "knnSearch(nn=" << num_results << "): \n";
     for (size_t i = 0; i < resultSet.size(); i++)

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -89,6 +89,12 @@ T pi_const()
     return static_cast<T>(3.14159265358979323846);
 }
 
+template <int v>
+struct Int2Type
+{
+    enum { value = v };
+};
+
 /**
  * Traits if object is resizable and assignable (typically has a resize | assign
  * method)
@@ -1636,10 +1642,11 @@ class KDTreeSingleIndexAdaptor
     using Offset    = typename Base::Offset;
     using Size      = typename Base::Size;
     using Dimension = typename Base::Dimension;
-
+ 
     using ElementType  = typename Base::ElementType;
     using DistanceType = typename Base::DistanceType;
     using IndexType    = typename Base::IndexType;
+    using PointType    = typename Base::PointType;
 
     using Node    = typename Base::Node;
     using NodePtr = Node*;
@@ -2030,11 +2037,19 @@ class KDTreeSingleIndexAdaptor
     {
         // Check intersection between node's bounding box and the line segment.
         DistanceType worst_dist = result_set.worstDist();
-        if (!dataset_.kdtree_intersects(lineSegStart, lineSegEnd, bbox, worst_dist, (DIM > 0 ? DIM : Base::dim_)))
-            return true;
+        if (DIM > 0)
+        {
+            if (!dataset_.kdtree_intersects(lineSegStart, lineSegEnd, bbox, worst_dist, Int2Type<DIM>()))
+                return true;
+        }
+        else
+        {
+            if (!dataset_.kdtree_intersects(lineSegStart, lineSegEnd, bbox, worst_dist, Base::dim_))
+                return true;
+        }
 
         // check all items stored in this node
-        for (IndexType i = node->lr.left; i < node->lr.right; ++i)
+        for (Offset i = node->lr.left; i < node->lr.right; ++i)
         {
             const IndexType index = vAcc_[i];  // reorder... : i;
             DistanceType    dist  = distance_.evalMetric(lineSegStart, lineSegEnd, index, (DIM > 0 ? DIM : Base::dim_));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 
 # Test project:
 ADD_EXECUTABLE(unit_tests test_main.cpp)
-set_target_properties(unit_tests PROPERTIES FOLDER "./")
+#set_target_properties(unit_tests PROPERTIES FOLDER "./")
 ADD_TEST(unit_tests_build "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target unit_tests)
 ADD_TEST(unit_tests_run ${EXECUTABLE_OUTPUT_PATH}/unit_tests)
 set_tests_properties(unit_tests_run PROPERTIES DEPENDS unit_tests_build)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv)
     return RUN_ALL_TESTS();
 }
 
-template <typename num_t>
+template <typename num_t, bool LOOSETREE>
 void L2_vs_L2_simple_test(const size_t N, const size_t num_results)
 {
     PointCloud<num_t> cloud;
@@ -61,11 +61,13 @@ void L2_vs_L2_simple_test(const size_t N, const size_t num_results)
     // construct a kd-tree index:
     using my_kd_tree_simple_t = KDTreeSingleIndexAdaptor<
         L2_Simple_Adaptor<num_t, PointCloud<num_t>>, PointCloud<num_t>,
-        3 /* dim */
+        3 /* dim */,
+        uint32_t /* index type*/,
+        LOOSETREE
         >;
 
     using my_kd_tree_t = KDTreeSingleIndexAdaptor<
-        L2_Adaptor<num_t, PointCloud<num_t>>, PointCloud<num_t>, 3 /* dim */
+        L2_Adaptor<num_t, PointCloud<num_t>>, PointCloud<num_t>, 3 /* dim */, uint32_t /* index type */, LOOSETREE
         >;
 
     my_kd_tree_simple_t index1(
@@ -596,8 +598,11 @@ TEST(kdtree, L2_vs_L2_simple)
 {
     for (int nResults = 1; nResults < 10; nResults++)
     {
-        L2_vs_L2_simple_test<float>(100, nResults);
-        L2_vs_L2_simple_test<double>(100, nResults);
+        L2_vs_L2_simple_test<float, false>(100, nResults);
+        L2_vs_L2_simple_test<double, false>(100, nResults);
+
+        L2_vs_L2_simple_test<float, true>(100, nResults);
+        L2_vs_L2_simple_test<double, true>(100, nResults);
     }
 }
 


### PR DESCRIPTION
The kd-trees can store now also the points in the middle nodes, if a cut runs through the point. This is possible only if a point is not actually a point, but it has a volume - like a bounding sphere. To support more complex volumetric points, there is added a search method which accepts 2 points (line segment) and it is up to the developer how the 2 points are interpreted. They can represent a line segment, bounding box (min, max points), bounding sphere (center and point on the surface to define the radius), etc.