### PR TITLE
Custom/kol/borm 29462 fix crash during building kdtree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------------
 # Root CMake file for nanoflann
 # ----------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 # Extract library version into "NANOFLANN_VERSION"
 # -----------------------------------------------------
@@ -37,6 +37,8 @@ endif()
 if(MSVC)
 	 add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /nologo" )
 endif()
+
+set(CMAKE_CXX_STANDARD 20)
 
 # Solution Folder options:
 if (${CMAKE_SOURCE_DIR} STREQUAL ${PROJECT_SOURCE_DIR})

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -105,7 +105,7 @@ struct PointCloud
 
 	// Intersection between node's bounding box and line segment (required only if nanoflann::KDTreeSingleIndexAdaptor<>::lineSegSearch is used)
 	template<class BBOX>
-	bool kdtree_intersects(const PointType& minPoint, const PointType& maxPoint, const BBOX& bbox, T max_dist, size_t /*dim*/) const
+	bool kdtree_intersects(const PointType& minPoint, const PointType& maxPoint, const BBOX& bbox, T max_dist, nanoflann::Int2Type<3>) const
 	{
 		const auto minmaxx = std::minmax(minPoint.x, maxPoint.x);
 		if (minmaxx.second + max_dist < bbox[0].low || bbox[0].high + max_dist < minmaxx.first)

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1441,10 +1441,11 @@ class KDTreeBaseClass
                 while (left <= right &&
                        !dataset_is_overlap(obj, vAcc_[ind + left], cutfeat, cutval))
                     ++left;
-                while (left <= right &&
+                while (right && left <= right &&
                        dataset_is_overlap(obj, vAcc_[ind + right], cutfeat, cutval))
                     --right;
-                if (left > right) break;
+                if (left > right || !right)
+                    break;  // "!right" was added to support unsigned Index types
                 std::swap(vAcc_[ind + left], vAcc_[ind + right]);
                 ++left;
                 --right;

--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1708,7 +1708,7 @@ class KDTreeSingleIndexAdaptor
         Base::size_                = dataset_.kdtree_get_point_count();
         Base::size_at_index_build_ = Base::size_;
         Base::dim_                 = dimensionality;
-        if (DIM > 0) Base::dim_ = DIM;
+        if constexpr (DIM > 0) Base::dim_ = DIM;
         Base::leaf_max_size_ = params.leaf_max_size;
         if (params.n_thread_build > 0)
         {
@@ -2037,7 +2037,7 @@ class KDTreeSingleIndexAdaptor
     {
         // Check intersection between node's bounding box and the line segment.
         DistanceType worst_dist = result_set.worstDist();
-        if (DIM > 0)
+        if constexpr (DIM > 0)
         {
             if (!dataset_.kdtree_intersects(lineSegStart, lineSegEnd, bbox, worst_dist, Int2Type<DIM>()))
                 return true;
@@ -2209,7 +2209,7 @@ class KDTreeSingleIndexDynamicAdaptor_
         Base::size_at_index_build_ = 0;
         for (auto& v : Base::root_bbox_) v = {};
         Base::dim_ = dimensionality;
-        if (DIM > 0) Base::dim_ = DIM;
+        if constexpr (DIM > 0) Base::dim_ = DIM;
         Base::leaf_max_size_ = params.leaf_max_size;
         if (params.n_thread_build > 0)
         {
@@ -2252,7 +2252,7 @@ class KDTreeSingleIndexDynamicAdaptor_
         this->freeIndex(*this);
         Base::size_at_index_build_ = Base::size_;
         if (Base::size_ == 0) return;
-        computeBoundingBox(*this, Base::vAcc_.data(), Base::vAcc_.size(), Base::root_bbox_);
+        Base::computeBoundingBox(*this, Base::vAcc_.data(), Base::vAcc_.size(), Base::root_bbox_);
 
         // construct the tree
         if (Base::n_thread_build_ == 1)
@@ -2595,7 +2595,7 @@ class KDTreeSingleIndexDynamicAdaptor
         pointCount_ = 0U;
         dim_        = dimensionality;
         treeIndex_.clear();
-        if (DIM > 0) dim_ = DIM;
+        if constexpr (DIM > 0) dim_ = DIM;
         leaf_max_size_ = params.leaf_max_size;
         init();
         const size_t num_initial_points = dataset_.kdtree_get_point_count();

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -178,7 +178,7 @@ void L2_vs_bruteforce_test(
     nanoflann::KNNResultSet<NUM> resultSet(num_results);
 
     resultSet.init(&ret_indexes[0], &out_dists_sqr[0]);
-    mat_index.index->findNeighbors(resultSet, my_kd_tree_t::PointType{query_pt});
+    mat_index.index->findNeighbors(resultSet, my_kd_tree_t::PointType(query_pt));
 
     const auto nFound = resultSet.size();
 
@@ -250,7 +250,7 @@ void rknn_L2_vs_bruteforce_test(
     nanoflann::RKNNResultSet<NUM> resultSet(num_results, maxRadiusSqr);
 
     resultSet.init(&ret_indexes[0], &out_dists_sqr[0]);
-    mat_index.index->findNeighbors(resultSet, my_kd_tree_t::PointType{query_pt});
+    mat_index.index->findNeighbors(resultSet, my_kd_tree_t::PointType(query_pt));
 
     const auto nFound = resultSet.size();
 
@@ -539,7 +539,7 @@ void L2_concurrent_build_vs_bruteforce_test(
     nanoflann::KNNResultSet<NUM> resultSet(num_results);
 
     resultSet.init(&ret_indexes[0], &out_dists_sqr[0]);
-    mat_index.index->findNeighbors(resultSet, my_kd_tree_t::PointType{query_pt});
+    mat_index.index->findNeighbors(resultSet, my_kd_tree_t::PointType(query_pt));
 
     // Brute force:
     double min_dist_L2 = std::numeric_limits<double>::max();

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -986,3 +986,21 @@ TEST(kdtree, BoxSearch)
     box_search_test<float, true>();
     box_search_test<double, true>();
 }
+
+// The test is about verification of building kd-tree with identical points for which the function KDTreeBaseClass::planeSplit crashed before fixing it.
+TEST(kdtree, OverlapWithLooseTree)
+{
+    using num_t = double;
+    PointCloud<num_t> cloud;
+    cloud.pts = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
+
+    // construct a kd-tree index:
+    typedef KDTreeSingleIndexAdaptor<
+        L2_Simple_Adaptor<num_t, PointCloud<num_t>>, PointCloud<num_t>,
+        3 /* dim */, uint32_t, true>
+        my_kd_tree_simple_t;
+
+    my_kd_tree_simple_t index(3 /*dim*/, cloud, KDTreeSingleIndexAdaptorParams(3 /* max leaf */, KDTreeSingleIndexAdaptorFlags::SkipInitialBuildIndex));
+    index.buildIndex();
+    EXPECT_TRUE(index.root_node_ != nullptr);
+}


### PR DESCRIPTION
Fixed KDTreeBaseClass::planeSplit. There were a problem with unsigned types used for Offset sub-type for which if it was decremented when it was already 0, the numbers overflew. The implementation is copied from the code within the same method where similar loops are already implemented with the same comments about supported unsigned types.