### PR TITLE
BORM-30158 Fixed computation of bounding boxes.

### DIFF
--- a/include/nanoflann.hpp
+++ b/include/nanoflann.hpp
@@ -1146,18 +1146,7 @@ class KDTreeBaseClass
 
         for (Dimension i = 0; i < dims; ++i)
         {
-            bbox[i].low = bbox[i].high = dataset_get(obj, ix[0], i);
-        }
-        for (Size k = 1; k < count; ++k)
-        {
-            for (Dimension i = 0; i < dims; ++i)
-            {
-                const auto val = dataset_get(obj, ix[k], i);
-                if (val < bbox[i].low)
-                    bbox[i].low = val;
-                if (val > bbox[i].high)
-                    bbox[i].high = val;
-            }
+            dataset_get_limits(obj, ix, count, i, bbox[i].low, bbox[i].high);
         }
     }
 


### PR DESCRIPTION
The bounding boxes must consider the volumetric points as well (like circles, rectangles, spheres, boxes) to compute properly the bounding boxes used by kd-trees. The previous implementation took only a single point (x, y, z) and merge it with the currently computed bounding box which was incorrected in the case of e.g. rectangles as it is used by Pointline.